### PR TITLE
fix tool.jar path problem of oracle jdk under mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,36 +40,26 @@
 
 	<profiles>
 		<profile>
-			<id>unix_profile</id>
+			<id>use-standard-tool-jar</id>
 			<activation>
-				<os>
-					<family>unix</family>
-				</os>
+				<file>
+					<exists>${java.home}/../lib/tools.jar</exists>
+				</file>
 			</activation>
 			<properties>
-				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+				<tools-jar-path>${java.home}/../lib/tools.jar</tools-jar-path>
 			</properties>
 		</profile>
 		<profile>
-			<id>windows_profile</id>
+			<!-- Only for mac brewed jdk, tool.jar is put at ${java.home}/../Classes/classes.jar. -->
+			<id>tool-jar-use-classes-jar</id>
 			<activation>
-				<os>
-					<family>windows</family>
-				</os>
+				<file>
+					<exists>${java.home}/../Classes/classes.jar</exists>
+				</file>
 			</activation>
 			<properties>
-				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-			</properties>
-		</profile>
-		<profile>
-			<id>osx_profile</id>
-			<activation>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
+				<tools-jar-path>${java.home}/../Classes/classes.jar</tools-jar-path>
 			</properties>
 		</profile>
 	</profiles>
@@ -88,7 +78,7 @@
 			<artifactId>tools</artifactId>
 			<version>1.6.0</version>
 			<scope>system</scope>
-			<systemPath>${toolsjar}</systemPath>
+			<systemPath>${tools-jar-path}</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
fix `tool.jar` path problem of `oracle jdk` under mac.

```
Missing:
----------
1) com.sun:tools:jar:1.6.0

  Try downloading the file manually from the project website.

  Then, install it using the command:
      mvn install:install-file -DgroupId=com.sun -DartifactId=tools -Dversion=1.6.0 -Dpackaging=jar -Dfile=/path/to/file

  Alternatively, if you host your own repository you can deploy the file there:
      mvn deploy:deploy-file -DgroupId=com.sun -DartifactId=tools -Dversion=1.6.0 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

  Path to dependency:
    1) com.github.pfmiles:kan-java:jar:0.1-SNAPSHOT
    2) com.sun:tools:jar:1.6.0
```

tool.jar path of oracle jdk under mac is same of other.

PS:

Only for mac brewed jdk, `tool.jar` is put at `${java.home}/../Classes/classes.jar`.
